### PR TITLE
Rails 3 compatibility

### DIFF
--- a/lib/apn.rb
+++ b/lib/apn.rb
@@ -2,6 +2,7 @@ require 'resque'
 require 'resque/plugins/access_worker_from_job'
 require 'resque/hooks/before_unregister_worker'
 require 'json'
+require 'active_support'
 
 require 'apn/queue_name'
 require 'apn/queue_manager'

--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -67,7 +67,7 @@ module APN
         hsh['aps']['sound'] = sound.is_a?(TrueClass) ? 'default' : sound.to_s
       end
       hsh.merge!(opts)
-      hsh.to_json
+      ActiveSupport::JSON::encode(hsh)
     end
     
     # Symbolize keys, using ActiveSupport if available


### PR DESCRIPTION
This fixes the unicode characters not being pushed to APNS. Seems it is a problem with to_json in Rails 3. Changed it to use ActiveSupport::JSON::encode()

Please note this has not been tested on Rails 2.x
