### PR TITLE
passing an alert dictionary instead of a string

### DIFF
--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -61,7 +61,10 @@ module APN
     def packaged_message
       opts = @options.clone # Don't destroy our pristine copy
       hsh = {'aps' => {}}
-      hsh['aps']['alert'] = opts.delete(:alert).to_s if opts[:alert]
+      if alert = opts.delete(:alert)
+        alert = alert.to_s unless alert.is_a?(Hash)
+        hsh['aps']['alert'] = alert
+      end
       hsh['aps']['badge'] = opts.delete(:badge).to_i if opts[:badge]
       if sound = opts.delete(:sound)
         hsh['aps']['sound'] = sound.is_a?(TrueClass) ? 'default' : sound.to_s


### PR DESCRIPTION
Hi Kali,

This is the patch to support sending an alert dictionary instead of a string. It is working fine for me; I am able to send notifications which load their text from localized resources in the app, set custom text on the action button, etc. I didn't try to validate the schema at all; apn_sender in general doesn't do strong validation on the input and for my application it isn't needed since the data is mostly static except for some substitution strings; I have application unit tests that validate that my code is constructing the expected dictionary.

Thanks,
.seth
