### PR TITLE
If payload length is 256, it make a wrong notification.

### DIFF
--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -47,7 +47,7 @@ module APN
     def packaged_notification
       pt = packaged_token
       pm = packaged_message
-      [0, 0, 32, pt, 0, pm.size, pm].pack("ccca*cca*") 
+      [0, 0, 32, pt, pm.size, pm].pack("ccca*na*")
     end
 
     # Device token, compressed and hex-ified


### PR DESCRIPTION
Payload length is 16-bit unsigned, network (big-endian) byte order.
