### PR TITLE
Fixed generating payload with diacritic/multibyte characters

### DIFF
--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -48,7 +48,7 @@ module APN
     def packaged_notification
       pt = packaged_token
       pm = packaged_message
-      [0, 0, 32, pt, 0, pm.size, pm].pack("ccca*cca*")
+      [0, 0, 32, pt, 0, pm.bytesize, pm].pack("ccca*cca*")
     end
 
     # Device token, compressed and hex-ified


### PR DESCRIPTION
**size** returns number of characters but Apple expect size in bytes, so **size** will return too small number if multibyte characters are used.
