### PR TITLE
reset socket on ETIMEDOUT

### DIFF
--- a/lib/apn/client.rb
+++ b/lib/apn/client.rb
@@ -22,7 +22,7 @@ module APN
 
       APN.log(:debug, "Message sent.")
       true
-    rescue OpenSSL::SSL::SSLError, Errno::EPIPE => e
+    rescue OpenSSL::SSL::SSLError, Errno::EPIPE, Errno::ETIMEDOUT => e
       APN.log(:error, "[##{self.object_id}] Exception occurred: #{e.inspect}, socket state: #{socket.inspect}")
       reset_socket
       APN.log(:debug, "[##{self.object_id}] Socket reestablished, socket state: #{socket.inspect}")


### PR DESCRIPTION
If left idle for a long period of time, the APN connection will raise an ETIMEDOUT error, so rescue that along with the other errors that induce a socket reset and request retry.
