### PR TITLE
content-available support

### DIFF
--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -74,7 +74,7 @@ module APN
             hsh['aps']['sound'] = sound.is_a?(TrueClass) ? 'default' : sound.to_s
           end
           if content_avaliable = opts.delete(:content_available)
-            hsh['aps']['content-available'] = 1 if content_avaliable == (true || 1)
+            hsh['aps']['content-available'] = 1 if (content_avaliable == true || content_avaliable == 1)
           end
           hsh.merge!(opts)
           payload(hsh)


### PR DESCRIPTION
For iOS7 remote-notification background fetch (application:didReceiveRemoteNotification:fetchCompletionHandler)

{ content-available: 1 } must be in aps hash.

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html

see Table 3-1 Keys and values of the aps dictionary

Example Usage:

```
          APN.notify_async(token, { alert: alert,
                                    data: data,
                                    content_available: true,
                                    sound: 'default'
                                   })
```

NB. APNS expects the dashed name ['aps']['content-available'], however snake_case is used to preserve the simple use of ruby keys.
