### PR TITLE
Don't use ActiveSupport 4.1.0

### DIFF
--- a/apn_sender.gemspec
+++ b/apn_sender.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency("connection_pool", [">= 0"])
-  s.add_dependency("activesupport", [">= 3.1", "< 4.1.0"])
+  s.add_dependency("activesupport", [">= 3.1", "!= 4.1.0"])
   s.add_dependency("daemons")
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)


### PR DESCRIPTION
Currently because of https://github.com/arthurnn/apn_sender/commit/bd6b79073f667034e1d6b3adcd5a83a2632e99fb it's not possible to run with newer version of rails
```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    apn_sender (~> 2.0.2) ruby depends on
      activesupport (< 4.1.0, >= 3.1) ruby

    activeadmin (>= 0) ruby depends on
      activesupport (4.1.5)
```
I'm not sure if activesupport 4.1.0 breaks anything (tried, all tests passes), but at least don't block > 4.1.0