### PR TITLE
Changed DATA_MAX_BYTES to 255 bytes

### DIFF
--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -21,7 +21,7 @@ module APN
     # Available to help clients determine before they create the notification if their message will be too large.
     # Each iPhone Notification payload must be 256 or fewer characters (not including the token or other push data), see Apple specs at:
     # https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4
-    DATA_MAX_BYTES = 256
+    DATA_MAX_BYTES = 255
 
     attr_accessor :options, :token
     def initialize(token, opts)

--- a/spec/apn/notification_spec.rb
+++ b/spec/apn/notification_spec.rb
@@ -117,7 +117,7 @@ describe APN::Notification do
       end
 
       it "has payload truncated only the alert" do
-        expect(notification.packaged_message).to eq({aps:{alert: "a" * 236 }}.to_json)
+        expect(notification.packaged_message).to eq({aps:{alert: "a" * 235 }}.to_json)
       end
     end
 
@@ -138,8 +138,8 @@ describe APN::Notification do
     context "when payload is multibyte string" do
       let(:payload) { "»" * 256 }
 
-      it "truncates the alert" do
-        expect(notification.payload_size).to eq(APN::Notification::DATA_MAX_BYTES)
+      it "truncates the alert in a way that no multibyte character gets truncated " do
+        expect(notification.payload_size).to eq(APN::Notification::DATA_MAX_BYTES - 1)
       end
 
       it "has different payload size and message size" do


### PR DESCRIPTION
It seems that notifications which are exactly 256 bytes are not being delivered due to message size. One reason for this could be that the byte representing the payload size is also summed.
