### PR TITLE
Use custom logger if configured, fallback to Rails.logger/STDOUT only if not

### DIFF
--- a/lib/apn.rb
+++ b/lib/apn.rb
@@ -49,7 +49,7 @@ module APN
     end
 
     def logger
-      @logger ||= Logger.new(STDOUT)
+      @logger ||= (defined?(Rails) ? Rails.logger : Logger.new(STDOUT))
     end
 
     def truncate_alert

--- a/lib/apn/railtie.rb
+++ b/lib/apn/railtie.rb
@@ -7,7 +7,6 @@ module APN
         APN.certificate_name =  "apn_development.pem"
         APN.host =  "gateway.sandbox.push.apple.com"
       end
-      APN.logger = Rails.logger
     end
   end
 end

--- a/lib/apn/tasks.rb
+++ b/lib/apn/tasks.rb
@@ -16,7 +16,6 @@ namespace :apn do
     APN.backend = :resque
     APN.password = ENV['CERT_PASS']
     APN.full_certificate_path =  ENV['FULL_CERT_PATH']
-    APN.logger = Rails.logger
 
     worker = ::Resque::Worker.new(APN::Jobs::QUEUE_NAME)
 


### PR DESCRIPTION
According to docs, you can set custom logger for APNs

```
APN.logger = Logger.new(File.join(Rails.root, 'log', 'apn_sender.log'))
```

But it's overwritten by Rails.logger (and it's cool beacause heroku deploys won't work otherwise, as discussed here https://github.com/arthurnn/apn_sender/issues/56). The drawback is that you cannot specify custom logger any more. So this patch should add usage of defined one, and fallback to Rails.logger/STDOUT if not.
What do you think?
