### PR TITLE
Support ActiveSupport 4.x.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,4 +32,11 @@ RSpec::Core::RakeTask.new('spec:progress') do |spec|
   spec.pattern = "spec/**/*_spec.rb"
 end
 
+task :console do
+  require 'pry'
+  require 'apn_sender'
+  ARGV.clear
+  Pry.start
+end
+
 task :default => :spec

--- a/apn_sender.gemspec
+++ b/apn_sender.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", [">= 3.1", "< 5.0.0"])
   s.add_dependency("daemons")
 
+  s.add_development_dependency "pry"
+
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)
   s.require_path = 'lib'
 end

--- a/apn_sender.gemspec
+++ b/apn_sender.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency("connection_pool", [">= 0"])
-  s.add_dependency("activesupport", [">= 3.1", "< 4.1.0"])
+  s.add_dependency("activesupport", [">= 3.1", "< 5.0.0"])
   s.add_dependency("daemons")
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)

--- a/lib/apn.rb
+++ b/lib/apn.rb
@@ -1,7 +1,6 @@
 require "openssl"
 require "socket"
-require "active_support"
-require "active_support/core_ext"
+require "active_support/all"
 require 'connection_pool'
 
 require "apn/version"

--- a/lib/apn.rb
+++ b/lib/apn.rb
@@ -1,7 +1,7 @@
 require "openssl"
 require "socket"
+require "active_support"
 require "active_support/core_ext"
-require "active_support/json"
 require 'connection_pool'
 
 require "apn/version"

--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -109,13 +109,7 @@ module APN
       end
 
       def truncate_alert(alert, max_size)
-        alert.each_char.each_with_object('') do |char, result|
-          if result.bytesize + char.bytesize > max_size
-            break result
-          else
-            result << char
-          end
-        end
+        alert.mb_chars.limit(max_size).to_s
       end
 
   end

--- a/lib/apn/notification.rb
+++ b/lib/apn/notification.rb
@@ -1,3 +1,5 @@
+require 'apn/payload'
+
 module APN
   # Encapsulates the logic necessary to convert an iPhone token and an array of options into a string of the format required
   # by Apple's servers to send the notification.  Much of the processing code here copied with many thanks from
@@ -78,39 +80,8 @@ module APN
             hsh['aps']['content-available'] = 1 if [1,true].include? content_available
           end
           hsh.merge!(opts)
-          payload(hsh)
+          Payload.new(hsh, DATA_MAX_BYTES).package
         end
     end
-
-    private
-
-      def payload(hash)
-        str = ActiveSupport::JSON::encode(hash)
-
-        if APN.truncate_alert && str.bytesize > DATA_MAX_BYTES
-          if hash['aps']['alert'].is_a?(Hash)
-            alert = hash['aps']['alert']['loc-args'][0]
-          else
-            alert = hash['aps']['alert']
-          end
-          max_bytesize = DATA_MAX_BYTES - (str.bytesize - alert.bytesize)
-
-          raise "Even truncating the alert won't be enough to have a #{DATA_MAX_BYTES} message" if max_bytesize <= 0
-          alert = truncate_alert(alert, max_bytesize)
-
-          if hash['aps']['alert'].is_a?(Hash)
-            hash['aps']['alert']['loc-args'][0] = alert
-          else
-            hash['aps']['alert'] = alert
-          end
-          str = ActiveSupport::JSON::encode(hash)
-        end
-        str
-      end
-
-      def truncate_alert(alert, max_size)
-        alert.mb_chars.limit(max_size).to_s
-      end
-
   end
 end

--- a/lib/apn/payload.rb
+++ b/lib/apn/payload.rb
@@ -1,0 +1,70 @@
+class Payload
+
+  def initialize(notification_hash, max_bytes)
+    @notification_hash = notification_hash
+    @max_bytes = max_bytes
+  end
+
+  def package
+    str = encode(@notification_hash)
+
+    if APN.truncate_alert && str.bytesize > @max_bytes
+      max_bytesize = @max_bytes - (str.bytesize - alert.bytesize)
+
+      if max_bytesize <= 0
+        escaped_max_bytesize = @max_bytes - (str.bytesize - encode(alert).bytesize)
+        raise "Even truncating the alert won't be enough to have a #{@max_bytes} message" if escaped_max_bytesize <= 0
+        truncate_escaped!(escaped_max_bytesize)
+      else
+        truncate_alert!(max_bytesize)
+      end
+      str = encode(@notification_hash)
+    end
+    str
+  end
+
+  private
+
+    def alert
+      @alert ||=
+      if hash_alert?
+        @notification_hash['aps']['alert']['loc-args'][0]
+      else
+        @notification_hash['aps']['alert']
+      end
+    end
+
+    def alert=(value)
+      if hash_alert?
+        @notification_hash['aps']['alert']['loc-args'][0] = value
+      else
+        @notification_hash['aps']['alert'] = value
+      end
+    end
+
+    def hash_alert?
+      @hash_alert ||= @notification_hash['aps']['alert'].is_a?(Hash)
+    end
+
+    def truncate_alert!(max_size)
+      self.alert = alert.mb_chars.limit(max_size).to_s
+    end
+
+    def truncate_escaped!(max_size)
+      self.alert = alert.each_char.each_with_object('') do |char, result|
+        if encoded_size(result) + encoded_size(char) > max_size
+          break result
+        else
+          result << char
+        end
+      end
+    end
+
+    def encode(obj)
+      ActiveSupport::JSON.encode(obj)
+    end
+
+    def encoded_size(str)
+      encode(str).bytesize - 2
+    end
+end

--- a/spec/apn/notification_spec.rb
+++ b/spec/apn/notification_spec.rb
@@ -142,8 +142,14 @@ describe APN::Notification do
         expect(notification.payload_size).to eq(APN::Notification::DATA_MAX_BYTES - 1)
       end
 
-      it "has different payload size and message size" do
-        expect(notification.packaged_message.size.to_i).to_not eq(notification.payload_size)
+      if ActiveSupport::VERSION::MAJOR == 4
+        it "has different payload size and message size" do
+          expect(notification.packaged_message.size.to_i).to_not eq(notification.payload_size)
+        end
+      elsif ActiveSupport::VERSION::MAJOR == 3
+        it "has the same payload size and message size" do
+          expect(notification.packaged_message.size.to_i).to eq(notification.payload_size)
+        end
       end
     end
   end


### PR DESCRIPTION
Adds support for 4.x.x versions of activesupport, refactors some notification-related code, and (I believe) addresses an issue with `ActiveSupport::JSON.encode` and notification alert truncation.