### PR TITLE
Support apple push protocol v2

### DIFF
--- a/spec/apn/notification_spec.rb
+++ b/spec/apn/notification_spec.rb
@@ -96,6 +96,23 @@ describe APN::Notification do
     end
   end
 
+  describe ".packaged_notification" do
+    it 'has the correct size' do
+      size = 1 + # command
+             4 + # frame_length
+             35 + # token_frame
+             27 # payload_frame
+      expect(notification.packaged_notification.bytesize).to eq(size)
+    end
+
+    it 'has the correct format' do
+      packaged = "\x02\x00\x00\x00\x3e" +
+        "\x01\x00\x20#{notification.packaged_token}" +
+        "\x02\x00\x18#{notification.packaged_message}"
+      expect(notification.packaged_notification).to eq(packaged)
+    end
+  end
+
   describe ".truncate_alert!" do
 
     before do


### PR DESCRIPTION
This adds support for version 2 of the APN protocol. According to
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4
this is needed to support push notifications of a payload size > 256 bytes.

Fixes #90.