### PR TITLE
Attempt to fix gem installation failures on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 2.2.4
   - 2.3.0
 script: rspec spec
+before_install:
+  - gem update bundler
 gemfile:
   - Gemfile
   - Gemfile.sidekiq


### PR DESCRIPTION
Travis is failing on ruby 1.9.3 and ruby 2.1 for reasons that seem related to those outlined here:
https://github.com/travis-ci/travis-ci/issues/3531