### PR TITLE
Update travis manifest so ruby <= 2.1 is tested with sidekiq 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,18 @@ gemfile:
   - Gemfile
   - Gemfile.sidekiq
   - Gemfile.resque
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: Gemfile.sidekiq
+    - rvm: 2.0.0
+      gemfile: Gemfile.sidekiq
+    - rvm: 2.1
+      gemfile: Gemfile.sidekiq
+  include:
+    - rvm: 1.9.3
+      gemfile: Gemfile.sidekiq.3.1
+    - rvm: 2.0.0
+      gemfile: Gemfile.sidekiq.3
+    - rvm: 2.1
+      gemfile: Gemfile.sidekiq.3

--- a/Gemfile.sidekiq.3
+++ b/Gemfile.sidekiq.3
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+gemspec
+
+gem "rake"
+gem "sidekiq", '~> 3.0'
+
+group :test do
+  gem "rspec", "~> 2.14.1"
+end

--- a/Gemfile.sidekiq.3.1
+++ b/Gemfile.sidekiq.3.1
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+gemspec
+
+gem "rake"
+gem "sidekiq", '~> 3.1.0'
+
+group :test do
+  gem "rspec", "~> 2.14.1"
+end


### PR DESCRIPTION
Sidekiq > 4.2 requires a version of rack-protection/rack which requires ruby > 2.2.2, so these test runs were failing on travis. See #96 

There may be a less verbose way to express this in .travis.yml but I think what's here should work.