### PR TITLE
Rails 5.1 compatibility

### DIFF
--- a/apn_sender.gemspec
+++ b/apn_sender.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "connection_pool"
-  s.add_dependency "activesupport", ">= 3.1", "< 5"
+  s.add_dependency "activesupport", ">= 3.1", "< 6"
   s.add_dependency "daemons"
 end


### PR DESCRIPTION
This changes multiple app support to use `Module.prepend` instead of `alias_method_chain`, which was deprecated in Rails 5, and removed in 5.1.
